### PR TITLE
V4 Release Candidate - Major improvements in Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# [4.0.0-beta.1](https://github.com/serverless-seoul/corgi/compare/v3.2.1-beta.1...v4.0.0-beta.1) (2020-09-25)
+
+
+### Bug Fixes
+
+* **typing:** use more strict types ([51aebb6](https://github.com/serverless-seoul/corgi/commit/51aebb6cd6d9a2809914e68e52a9729b4c056f8b))
+* add missing optional parameter type inference ([96714b5](https://github.com/serverless-seoul/corgi/commit/96714b58252d492ec0706efb35e56c73beb67cca))
+
+
+### Features
+
+* **openapi:** add schema reference merging ([f817e42](https://github.com/serverless-seoul/corgi/commit/f817e42ddec4f54628b04f62c139b4b62ad39c8d))
+* support automatic parameter type inference by using typebox ([598ad14](https://github.com/serverless-seoul/corgi/commit/598ad1475dcf382841b4f97189dc9b4b0a14ee7b))
+
+
+### BREAKING CHANGES
+
+* This change requires TypeScript 4 and Node.js 12
+
 ## [3.2.1-beta.1](https://github.com/serverless-seoul/corgi/compare/v3.2.0...v3.2.1-beta.1) (2020-09-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.0.0-beta.2](https://github.com/serverless-seoul/corgi/compare/v4.0.0-beta.1...v4.0.0-beta.2) (2020-09-25)
+
+
+### Bug Fixes
+
+* **parameter:** stripping out unknown parameter should work with oneOf (union) type ([7f6a5d9](https://github.com/serverless-seoul/corgi/commit/7f6a5d95df1950bb6573d49079fa4d7f3b1ca1f7))
+
 # [4.0.0-beta.1](https://github.com/serverless-seoul/corgi/compare/v3.2.1-beta.1...v4.0.0-beta.1) (2020-09-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [3.2.1-beta.1](https://github.com/serverless-seoul/corgi/compare/v3.2.0...v3.2.1-beta.1) (2020-09-25)
+
+
+### Bug Fixes
+
+* fix failing build due to path-to-regexp changes ([c5d695b](https://github.com/serverless-seoul/corgi/commit/c5d695b210c0c5a1a023fd42df31f5f22cf8f423))
+* **router:** apply path-to-regexp changes ([7af9e52](https://github.com/serverless-seoul/corgi/commit/7af9e52bf9462bcf9b7a52e345aee21ae3821763))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless-seoul/corgi",
-  "version": "3.2.0",
+  "version": "3.2.1-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2328,9 +2328,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "minimist-options": {
@@ -2345,12 +2345,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,11 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@catchfashion/typebox": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@catchfashion/typebox/-/typebox-1.0.1.tgz",
+      "integrity": "sha512-8bfzcKK0LjXXPe1vESLrbPFc4XwzfOWi64Ms6CqPhLX2Ot8O9Jp/gUDNYZA9MlwgdUrkSkNPA23O8l9DFgkgrw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -428,11 +433,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/joi": {
-      "version": "13.6.3",
-      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-13.6.3.tgz",
-      "integrity": "sha512-n5tDa0/3MUtHsA2fVH+emDfGQkPramIpWaOvWS+7C/Yq7bn2j979RAIy9pbl4F4hSE5lwjgBXhJN019DP+3ofg=="
-    },
     "@types/lodash": {
       "version": "4.14.161",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
@@ -522,6 +522,17 @@
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
+      }
+    },
+    "ajv": {
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-colors": {
@@ -1316,6 +1327,11 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "fast-glob": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
@@ -1329,6 +1345,11 @@
         "micromatch": "^4.0.2",
         "picomatch": "^2.2.1"
       }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fastq": {
       "version": "1.8.0",
@@ -1602,11 +1623,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "hoek": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
-      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
     },
     "hook-std": {
       "version": "2.0.0",
@@ -1900,21 +1916,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "isemail": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
-      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
-      "requires": {
-        "punycode": "2.x.x"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-        }
-      }
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1966,16 +1967,6 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
-    "joi": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
-      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
-      "requires": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2003,6 +1994,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -7132,21 +7128,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "topo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-      "requires": {
-        "hoek": "6.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "6.1.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
-        }
-      }
-    },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -7258,6 +7239,21 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
+    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -7293,11 +7289,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "vingle-corgi-joi-to-json-schema": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vingle-corgi-joi-to-json-schema/-/vingle-corgi-joi-to-json-schema-3.2.0.tgz",
-      "integrity": "sha512-caDRKj5VRxBrAfGIut1fO7cUAHmXrbRWQZXL8RTljOyaXWpinpCjnVGgRyyfOxJqE/WgY5xS1DF3KVhOiZlUZQ=="
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -406,9 +406,9 @@
       }
     },
     "@serverless-seoul/typebox": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@serverless-seoul/typebox/-/typebox-1.0.3.tgz",
-      "integrity": "sha512-ST5f867V7JuT9mP8tHup+Iv85RDezHtFB83EUp9LrngmJ8folL/PQpCShxPuyMN9uBaXICDvwg/1Ba+jNfi7ig=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@serverless-seoul/typebox/-/typebox-1.0.4.tgz",
+      "integrity": "sha512-lS1r0ZAKUB0ScHuLs7Z6eWbPedQVaAvOY5zSR9R4vpYIsa2KUslVZ7YIxAPdd0ZPnum5ibsa6Fm8sLVkM1El/w=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -476,6 +476,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
+    },
+    "@types/traverse": {
+      "version": "0.6.32",
+      "resolved": "https://registry.npmjs.org/@types/traverse/-/traverse-0.6.32.tgz",
+      "integrity": "sha512-RBz2uRZVCXuMg93WD//aTS5B120QlT4lR/gL+935QtGsKHLS6sCtZBaKfWjIfk7ZXv/r8mtGbwjVIee6/3XTow==",
       "dev": true
     },
     "JSONStream": {
@@ -7131,8 +7137,7 @@
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trim-newlines": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless-seoul/corgi",
-  "version": "3.2.1-beta.1",
+  "version": "4.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless-seoul/corgi",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@catchfashion/typebox": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@catchfashion/typebox/-/typebox-1.0.1.tgz",
-      "integrity": "sha512-8bfzcKK0LjXXPe1vESLrbPFc4XwzfOWi64Ms6CqPhLX2Ot8O9Jp/gUDNYZA9MlwgdUrkSkNPA23O8l9DFgkgrw=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -409,6 +404,11 @@
           "dev": true
         }
       }
+    },
+    "@serverless-seoul/typebox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@serverless-seoul/typebox/-/typebox-1.0.3.tgz",
+      "integrity": "sha512-ST5f867V7JuT9mP8tHup+Iv85RDezHtFB83EUp9LrngmJ8folL/PQpCShxPuyMN9uBaXICDvwg/1Ba+jNfi7ig=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless-seoul/corgi",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless-seoul/corgi",
-  "version": "3.2.1-beta.1",
+  "version": "4.0.0-beta.1",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@serverless-seoul/typebox": "^1.0.3",
+    "@serverless-seoul/typebox": "^1.0.4",
     "@types/aws-lambda": "^8.10.62",
     "@types/lodash": "^4.14.161",
     "@types/node": "^12.12.62",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@semantic-release/github": "^7.1.1",
     "@types/chai": "^4.2.12",
     "@types/mocha": "^8.0.3",
+    "@types/traverse": "0.6.32",
     "chai": "4.2.0",
     "check-engine": "1.8.1",
     "mocha": "^8.1.3",
@@ -58,6 +59,7 @@
     "lodash": "^4.17.20",
     "openapi3-ts": "^2.0.0",
     "path-to-regexp": "^6.1.0",
-    "qs": "^6.9.4"
+    "qs": "^6.9.4",
+    "traverse": "^0.6.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless-seoul/corgi",
-  "version": "3.2.0",
+  "version": "3.2.1-beta.1",
   "description": "Restful HTTP Framework for AWS Lambda - AWS API Gateway Proxy Integration",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -48,17 +48,16 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
+    "@catchfashion/typebox": "^1.0.1",
     "@types/aws-lambda": "^8.10.62",
-    "@types/joi": "^13.0.2",
     "@types/lodash": "^4.14.161",
     "@types/node": "^12.12.62",
     "@types/qs": "^6.9.5",
+    "ajv": "^6.12.5",
     "aws-xray-sdk-core": ">=1.1.6",
-    "joi": "^13.0.2",
     "lodash": "^4.17.20",
     "openapi3-ts": "^2.0.0",
     "path-to-regexp": "^6.1.0",
-    "qs": "^6.9.4",
-    "vingle-corgi-joi-to-json-schema": "^3.2.0"
+    "qs": "^6.9.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@catchfashion/typebox": "^1.0.1",
+    "@serverless-seoul/typebox": "^1.0.3",
     "@types/aws-lambda": "^8.10.62",
     "@types/lodash": "^4.14.161",
     "@types/node": "^12.12.62",

--- a/src/__test__/e2e/complex_api_spec.ts
+++ b/src/__test__/e2e/complex_api_spec.ts
@@ -1,4 +1,4 @@
-import { Type } from "@catchfashion/typebox";
+import { Type } from "@serverless-seoul/typebox";
 import { expect } from "chai";
 
 import {

--- a/src/__test__/e2e/complex_api_spec.ts
+++ b/src/__test__/e2e/complex_api_spec.ts
@@ -35,6 +35,7 @@ describe("Calling complex API", () => {
             children: [
               Route.POST("", { operationId: "follow" }, {
                 testId: Parameter.Query(Type.Number()),
+                optional: Parameter.Query(Type.Optional(Type.String())),
                 update: Parameter.Body(Type.Object({
                   fieldA: Type.Number(),
                 })),
@@ -44,6 +45,7 @@ describe("Calling complex API", () => {
 
                 return this.json({
                   testId,
+                  optional: this.params.optional,
                   userId,
                   update: this.params.update,
                 });

--- a/src/__test__/e2e/middleware_api_spec.ts
+++ b/src/__test__/e2e/middleware_api_spec.ts
@@ -1,4 +1,4 @@
-import { Type } from "@catchfashion/typebox";
+import { Type } from "@serverless-seoul/typebox";
 import { expect } from "chai";
 
 import {

--- a/src/__test__/e2e/middleware_api_spec.ts
+++ b/src/__test__/e2e/middleware_api_spec.ts
@@ -1,6 +1,6 @@
+import { Type } from "@catchfashion/typebox";
 import { expect } from "chai";
 
-import * as Joi from "joi";
 import {
   Middleware,
   MiddlewareAfterOptions,
@@ -15,9 +15,8 @@ describe("Calling complex middleware connected API", () => {
     const router = new Router(
       [
         new Namespace("/api/:userId", {
-          params: {
-            userId: Joi.number()
-          },
+          userId: Type.Number(),
+        }, {
           async exceptionHandler(error: Error) {
             // 2
             return this.json(

--- a/src/__test__/e2e/open_api_fixture.json
+++ b/src/__test__/e2e/open_api_fixture.json
@@ -1,0 +1,360 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "MyAPI",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.net/prod/"
+    }
+  ],
+  "tags": [],
+  "paths": {
+    "/me": {
+      "get": {
+        "description": "Describe current user",
+        "operationId": "describeMe",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserShow"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messages": {
+      "get": {
+        "description": "List Messages",
+        "operationId": "listMessages",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "count",
+            "schema": {
+              "minimum": 1,
+              "maximum": 100,
+              "type": "integer"
+            },
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "after",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageList"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new Message",
+        "operationId": "createMessage",
+        "parameters": [],
+        "requestBody": {
+          "description": "Body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "$ref": "#/components/schemas/Message"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageShow"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/messages/{id}": {
+      "get": {
+        "description": "Describe given message",
+        "operationId": "describeMessage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "integer"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageShow"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "Update given message",
+        "operationId": "updateMessage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "integer"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "description": "Body",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "$ref": "#/components/schemas/Message"
+                  }
+                },
+                "required": [
+                  "message"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageShow"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete given message",
+        "operationId": "deleteMessage",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "integer"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Succeeded"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Message": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "status": {
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "active"
+                ]
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "deleted"
+                ]
+              }
+            ]
+          },
+          "user": {
+            "$ref": "#/components/schemas/User"
+          },
+          "content": {
+            "type": "string"
+          },
+          "readonly": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "user",
+          "content"
+        ]
+      },
+      "MessageShow": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Message"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "MessageList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Message"
+            }
+          },
+          "paging": {
+            "type": "object",
+            "properties": {
+              "after": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "data",
+          "paging"
+        ]
+      },
+      "Succeeded": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "success": {
+                "type": "boolean",
+                "enum": [
+                  true
+                ]
+              }
+            },
+            "required": [
+              "success"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "email": {
+            "format": "email",
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "username"
+        ]
+      },
+      "UserShow": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
+      "UserList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "paging": {
+            "type": "object",
+            "properties": {
+              "after": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "data",
+          "paging"
+        ]
+      }
+    }
+  }
+}

--- a/src/__test__/e2e/open_api_fixture.json
+++ b/src/__test__/e2e/open_api_fixture.json
@@ -11,7 +11,7 @@
   ],
   "tags": [],
   "paths": {
-    "/me": {
+    "/api/me": {
       "get": {
         "description": "Describe current user",
         "operationId": "describeMe",
@@ -30,7 +30,7 @@
         }
       }
     },
-    "/messages": {
+    "/api/messages": {
       "get": {
         "description": "List Messages",
         "operationId": "listMessages",
@@ -104,7 +104,7 @@
         }
       }
     },
-    "/messages/{id}": {
+    "/api/messages/{id}": {
       "get": {
         "description": "Describe given message",
         "operationId": "describeMessage",

--- a/src/__test__/e2e/open_api_spec.ts
+++ b/src/__test__/e2e/open_api_spec.ts
@@ -1,0 +1,47 @@
+import { expect } from "chai";
+
+import {
+  Namespace,
+  OpenAPIRoute,
+  Router,
+} from "../../index";
+import { Routes, Schemas } from "./support";
+
+import * as OpenAPIFixture from "./open_api_fixture.json";
+
+describe("OpenAPI E2E Test", () => {
+  let router: Router;
+
+  beforeEach(() => {
+    router = new Router([
+      new Namespace("/api", {}, {
+        children: [
+          new OpenAPIRoute("/open-api", {
+            title: "MyAPI",
+            version: "1.0.0",
+            definitions: Schemas,
+          }, Routes),
+          ...Routes,
+        ],
+      }),
+    ]);
+  });
+
+  it("should return OpenAPI documentation", async () => {
+    const res = await router.resolve({
+      path: "/api/open-api",
+      httpMethod: "GET",
+      headers: {
+        "Host": "api.example.net",
+        "Origin": "https://foo.bar",
+        "X-Forwarded-Proto": "https",
+      },
+      requestContext: {
+        stage: "prod",
+      },
+    } as any, { requestId: "request-id", timeout: 10000 });
+
+    expect(res.statusCode).to.eq(200);
+    expect(JSON.parse(res.body)).to.deep.eq(OpenAPIFixture);
+  });
+});

--- a/src/__test__/e2e/open_api_spec.ts
+++ b/src/__test__/e2e/open_api_spec.ts
@@ -14,9 +14,9 @@ describe("OpenAPI E2E Test", () => {
 
   beforeEach(() => {
     router = new Router([
-      new Namespace("/api", {}, {
+      new Namespace("", {}, {
         children: [
-          new OpenAPIRoute("/open-api", {
+          new OpenAPIRoute("/api/open-api", {
             title: "MyAPI",
             version: "1.0.0",
             definitions: Schemas,

--- a/src/__test__/e2e/support/fixtures/index.ts
+++ b/src/__test__/e2e/support/fixtures/index.ts
@@ -1,0 +1,2 @@
+export * from "./message";
+export * from "./user";

--- a/src/__test__/e2e/support/fixtures/message.ts
+++ b/src/__test__/e2e/support/fixtures/message.ts
@@ -1,0 +1,26 @@
+import * as Models from "../models";
+import { Users } from "./user";
+
+export const Messages: Models.MessageRecord[] = [{
+  id: 1,
+  status: "active",
+  user: Users[0],
+  content: "one",
+  readonly: true,
+  createdAt: new Date("2020-01-02 03:04:05"),
+  updatedAt: new Date("2020-01-02 03:04:05"),
+}, {
+  id: 2,
+  status: "deleted",
+  user: Users[1],
+  content: "two",
+  createdAt: new Date("2020-02-02 03:04:05"),
+  updatedAt: new Date("2020-02-02 03:04:05"),
+}, {
+  id: 3,
+  status: "active",
+  user: Users[0],
+  content: "three",
+  createdAt: new Date("2020-03-02 03:04:05"),
+  updatedAt: new Date("2020-03-02 03:04:05"),
+}];

--- a/src/__test__/e2e/support/fixtures/user.ts
+++ b/src/__test__/e2e/support/fixtures/user.ts
@@ -1,0 +1,17 @@
+import * as Models from "../models";
+
+export const Users: Models.UserRecord[] = [{
+  id: 1,
+  username: "foo",
+  email: "foo@example.com",
+  password: "encrypted",
+  createdAt: new Date("2020-01-02 03:04:05"),
+  updatedAt: new Date("2020-01-02 03:04:05"),
+}, {
+  id: 2,
+  username: "bar",
+  email: "bar@example.com",
+  password: "encrypted2",
+  createdAt: new Date("2020-02-02 03:04:05"),
+  updatedAt: new Date("2020-02-02 03:04:05"),
+}];

--- a/src/__test__/e2e/support/index.ts
+++ b/src/__test__/e2e/support/index.ts
@@ -1,0 +1,5 @@
+export * as Fixtures from "./fixtures";
+export * as Models from "./models";
+export * as Presenters from "./presenters";
+export { routes as Routes } from "./routes";
+export * as Schemas from "./schemas";

--- a/src/__test__/e2e/support/models/index.ts
+++ b/src/__test__/e2e/support/models/index.ts
@@ -1,0 +1,2 @@
+export * from "./message";
+export * from "./user";

--- a/src/__test__/e2e/support/models/message.ts
+++ b/src/__test__/e2e/support/models/message.ts
@@ -1,0 +1,11 @@
+import { UserRecord } from "./user";
+
+export interface MessageRecord {
+  id: number;
+  user: UserRecord;
+  status: "active" | "deleted";
+  content: string;
+  readonly?: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/__test__/e2e/support/models/user.ts
+++ b/src/__test__/e2e/support/models/user.ts
@@ -1,0 +1,8 @@
+export interface UserRecord {
+  id: number;
+  email: string;
+  password: string;
+  username: string;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/__test__/e2e/support/presenters/helper.ts
+++ b/src/__test__/e2e/support/presenters/helper.ts
@@ -1,0 +1,22 @@
+import { Static } from "@serverless-seoul/typebox";
+import { Presenter } from "../../../../index";
+
+import * as Schemas from "../schemas";
+
+type AvailableSchema = (typeof Schemas)[keyof typeof Schemas];
+
+const SchemaNames = new Map<any, string>(
+  Object.entries(Schemas).map(([key, value]) => [value, key]),
+);
+
+export function createPresenter<Model, Schema extends AvailableSchema>(
+  schema: Schema,
+  present: (model: Model) => Promise<Static<Schema>>,
+): Presenter<Model, Static<Schema>> {
+  return {
+    outputJSONSchema: () => ({
+      $ref: `#/components/schemas/${SchemaNames.get(schema)!}`,
+    }),
+    present,
+  };
+}

--- a/src/__test__/e2e/support/presenters/index.ts
+++ b/src/__test__/e2e/support/presenters/index.ts
@@ -1,0 +1,3 @@
+export * from "./succeeded";
+export * from "./user";
+export * from "./message";

--- a/src/__test__/e2e/support/presenters/message.ts
+++ b/src/__test__/e2e/support/presenters/message.ts
@@ -1,0 +1,32 @@
+import * as Models from "../models";
+import * as Schemas from "../schemas";
+import { createPresenter } from "./helper";
+import { presentUser } from "./user";
+
+function presentMessage(message: Models.MessageRecord) {
+  return {
+    id: message.id,
+    status: message.status,
+    user: presentUser(message.user),
+    content: message.content,
+    readonly: message.readonly,
+  };
+}
+
+export const MessageList = createPresenter(Schemas.MessageList, async (input: {
+  data: Models.MessageRecord[];
+  paging: {
+    after?: string;
+  };
+}) => {
+  return {
+    data: input.data.map((message) => presentMessage(message)),
+    paging: input.paging,
+  };
+});
+
+export const MessageShow = createPresenter(Schemas.MessageShow, async (message: Models.MessageRecord) => {
+  return {
+    data: presentMessage(message),
+  };
+});

--- a/src/__test__/e2e/support/presenters/succeeded.ts
+++ b/src/__test__/e2e/support/presenters/succeeded.ts
@@ -1,0 +1,6 @@
+import * as Schemas from "../schemas";
+import { createPresenter } from "./helper";
+
+export const Succeeded = createPresenter(Schemas.Succeeded, async (success: true) => {
+  return { data: success };
+});

--- a/src/__test__/e2e/support/presenters/user.ts
+++ b/src/__test__/e2e/support/presenters/user.ts
@@ -1,0 +1,30 @@
+import * as Models from "../models";
+import * as Schemas from "../schemas";
+
+import { createPresenter } from "./helper";
+
+export function presentUser(user: Models.UserRecord) {
+  return {
+    id: user.id,
+    email: user.email,
+    username: user.username,
+  };
+}
+
+export const UserList = createPresenter(Schemas.UserList, async (input: {
+  data: Models.UserRecord[];
+  paging: {
+    after?: string;
+  };
+}) => {
+  return {
+    data: input.data.map((user) => presentUser(user)),
+    paging: input.paging,
+  };
+});
+
+export const UserShow = createPresenter(Schemas.UserShow, async (user: Models.UserRecord) => {
+  return {
+    data: presentUser(user),
+  };
+});

--- a/src/__test__/e2e/support/routes/index.ts
+++ b/src/__test__/e2e/support/routes/index.ts
@@ -1,0 +1,8 @@
+import { Routes } from "../../../../namespace";
+import { route as Me } from "./me";
+import { route as Messages } from "./messages";
+
+export const routes: Routes = [
+  Me,
+  Messages,
+];

--- a/src/__test__/e2e/support/routes/me.ts
+++ b/src/__test__/e2e/support/routes/me.ts
@@ -1,0 +1,14 @@
+import { Namespace, PresenterRouteFactory } from "../../../../index";
+import * as Fixtures from "../fixtures";
+import * as Presenters from "../presenters";
+
+export const route = new Namespace("/me", {}, {
+  children: [
+    PresenterRouteFactory.GET("", {
+      operationId: "describeMe",
+      desc: "Describe current user",
+    }, {}, Presenters.UserShow, async function() {
+      return Fixtures.Users[0];
+    }),
+  ],
+});

--- a/src/__test__/e2e/support/routes/me.ts
+++ b/src/__test__/e2e/support/routes/me.ts
@@ -2,7 +2,7 @@ import { Namespace, PresenterRouteFactory } from "../../../../index";
 import * as Fixtures from "../fixtures";
 import * as Presenters from "../presenters";
 
-export const route = new Namespace("/me", {}, {
+export const route = new Namespace("/api/me", {}, {
   children: [
     PresenterRouteFactory.GET("", {
       operationId: "describeMe",

--- a/src/__test__/e2e/support/routes/messages.ts
+++ b/src/__test__/e2e/support/routes/messages.ts
@@ -1,0 +1,76 @@
+import { Type } from "@serverless-seoul/typebox";
+
+import { Namespace, Parameter, PresenterRouteFactory, StandardError } from "../../../../index";
+import * as Fixtures from "../fixtures";
+import * as Models from "../models";
+import * as Presenters from "../presenters";
+import * as Schemas from "../schemas";
+
+export const route = new Namespace("/messages", {}, {
+  children: [
+    PresenterRouteFactory.GET("", {
+      operationId: "listMessages",
+      desc: "List Messages",
+    }, {
+      count: Parameter.Query(Type.Optional(Type.Integer({ minimum: 1, maximum: 100 }))),
+      after: Parameter.Query(Type.Optional(Type.String())),
+    }, Presenters.MessageList, async function() {
+      this.params.count?.toFixed(3);
+      this.params.after?.slice(0, 3);
+      return {
+        data: Fixtures.Messages,
+        paging: { after: "afterKey" },
+      };
+    }),
+
+    PresenterRouteFactory.POST("", {
+      operationId: "createMessage",
+      desc: "Create a new Message",
+    }, {
+      message: Parameter.Body(Schemas.Message),
+    }, Presenters.MessageShow, async function() {
+      return this.params.message;
+    }),
+
+    new Namespace("/:id", {
+      id: Type.Integer(),
+    }, {
+      async before() {
+        const id = this.params.id;
+        const message = Fixtures.Messages.find((record) => record.id === id);
+        if (!message) {
+          throw new StandardError(404, {
+            code: "MESSAGE_NOT_FOUND",
+            message: "The request message does not exist",
+          });
+        }
+
+        this.params.record = message;
+      },
+      children: [
+        PresenterRouteFactory.GET("", {
+          operationId: "describeMessage",
+          desc: "Describe given message",
+        }, {}, Presenters.MessageShow, async function() {
+          return this.params.record as Models.MessageRecord;
+        }),
+
+        PresenterRouteFactory.PUT("", {
+          operationId: "updateMessage",
+          desc: "Update given message",
+        }, {
+          message: Parameter.Body(Schemas.Message),
+        }, Presenters.MessageShow, async function() {
+          return this.params.message;
+        }),
+
+        PresenterRouteFactory.DELETE("", {
+          operationId: "deleteMessage",
+          desc: "Delete given message",
+        }, {}, Presenters.Succeeded, async function() {
+          return true as const;
+        }),
+      ],
+    }),
+  ],
+});

--- a/src/__test__/e2e/support/routes/messages.ts
+++ b/src/__test__/e2e/support/routes/messages.ts
@@ -6,7 +6,7 @@ import * as Models from "../models";
 import * as Presenters from "../presenters";
 import * as Schemas from "../schemas";
 
-export const route = new Namespace("/messages", {}, {
+export const route = new Namespace("/api/messages", {}, {
   children: [
     PresenterRouteFactory.GET("", {
       operationId: "listMessages",

--- a/src/__test__/e2e/support/schemas/index.ts
+++ b/src/__test__/e2e/support/schemas/index.ts
@@ -1,0 +1,3 @@
+export * from "./message";
+export * from "./succeeded";
+export * from "./user";

--- a/src/__test__/e2e/support/schemas/layout.ts
+++ b/src/__test__/e2e/support/schemas/layout.ts
@@ -1,0 +1,16 @@
+import { TStatic, Type } from "@serverless-seoul/typebox";
+
+export function DataLayout(schema: TStatic) {
+  return Type.Object({
+    data: schema,
+  });
+}
+
+export function PaginatedDataLayout(schema: TStatic) {
+  return Type.Object({
+    data: Type.Array(schema),
+    paging: Type.Object({
+      after: Type.Optional(Type.String()),
+    }),
+  });
+}

--- a/src/__test__/e2e/support/schemas/message.ts
+++ b/src/__test__/e2e/support/schemas/message.ts
@@ -1,0 +1,17 @@
+import { Type } from "@serverless-seoul/typebox";
+import { DataLayout, PaginatedDataLayout } from "./layout";
+import { User } from "./user";
+
+export const Message = Type.Object({
+  id: Type.Integer(),
+  status: Type.Union([
+    Type.Literal("active"),
+    Type.Literal("deleted"),
+  ]),
+  user: User,
+  content: Type.String(),
+  readonly: Type.Optional(Type.Boolean()),
+});
+
+export const MessageShow = DataLayout(Message);
+export const MessageList = PaginatedDataLayout(Message);

--- a/src/__test__/e2e/support/schemas/succeeded.ts
+++ b/src/__test__/e2e/support/schemas/succeeded.ts
@@ -1,0 +1,6 @@
+import { Type } from "@serverless-seoul/typebox";
+import { DataLayout } from "./layout";
+
+export const Succeeded = DataLayout(Type.Object({
+  success: Type.Literal(true),
+}));

--- a/src/__test__/e2e/support/schemas/user.ts
+++ b/src/__test__/e2e/support/schemas/user.ts
@@ -1,0 +1,11 @@
+import { Type } from "@serverless-seoul/typebox";
+import { DataLayout, PaginatedDataLayout } from "./layout";
+
+export const User = Type.Object({
+  id: Type.Integer(),
+  email: Type.String({ format: "email" }),
+  username: Type.String(),
+});
+
+export const UserShow = DataLayout(User);
+export const UserList = PaginatedDataLayout(User);

--- a/src/__test__/namespace_spec.ts
+++ b/src/__test__/namespace_spec.ts
@@ -7,7 +7,7 @@ describe("Namespace", () => {
   describe("#constructor", () => {
     it("should construct object with given options", () => {
       const namespace  =
-        new Namespace("/api", {
+        new Namespace("/api", {}, {
           children: [
             Route.GET("/test", { operationId: "test" }, {}, async function() {
               return this.json({});
@@ -21,7 +21,7 @@ describe("Namespace", () => {
 
     it("should raise error when there is no child", () => {
       expect(function() {
-        return new Namespace("/api", { children: [] });
+        return new Namespace("/api", {}, { children: [] });
       }).to.throw(Error);
     });
   });

--- a/src/__test__/route_spec.ts
+++ b/src/__test__/route_spec.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 
 import { Route } from "../route";
-import { RoutingContext } from "../routing-context";
 
 describe("Route", () => {
   describe("#constructor", () => {
@@ -12,7 +11,7 @@ describe("Route", () => {
           method: "GET",
           operationId: "getFollowers",
           desc: "List of users that following me",
-          async handler(this: RoutingContext) {
+          async handler() {
             return this.json({
               data: {}
             });
@@ -39,7 +38,7 @@ describe("Route", () => {
           metadata: new Map([
             [A, { x: 200 }],
           ]),
-          async handler(this: RoutingContext) {
+          async handler() {
             return this.json({
               data: {}
             });

--- a/src/__test__/router_spec.ts
+++ b/src/__test__/router_spec.ts
@@ -129,7 +129,7 @@ describe("Router", () => {
 
     it("should raise timeout if it's really get delayed", async () => {
       const router = new Router([
-        new Namespace("/", {
+        new Namespace("/", {}, {
           async exceptionHandler(error: Error) {
             if (error instanceof TimeoutError) {
               return this.json({

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -206,11 +206,7 @@ describe("RoutingContext", () => {
           ),
         });
 
-        expect(context.params).to.deep.eq({
-          // update: {
-          //   complex: null,
-          // },
-        });
+        expect(context.params).to.deep.eq({});
       });
     });
   });

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -1,6 +1,6 @@
+import { Type } from "@catchfashion/typebox";
 import { expect } from "chai";
 
-import * as Joi from "joi";
 import * as qs from "qs";
 import { Parameter } from "../parameter";
 import { RoutingContext } from "../routing-context";
@@ -36,17 +36,17 @@ describe("RoutingContext", () => {
         });
 
         context.validateAndUpdateParams({
-          testId: Parameter.Query(Joi.number()),
-          encodedParam: Parameter.Query(Joi.string()),
-          update: Parameter.Body(Joi.object({
-            fieldA: Joi.number(),
-            fieldC: Joi.object({
-              c: Joi.number()
+          testId: Parameter.Query(Type.Number()),
+          encodedParam: Parameter.Query(Type.String()),
+          update: Parameter.Body(Type.Object({
+            fieldA: Type.Number(),
+            fieldC: Type.Object({
+              c: Type.Number()
             })
           })),
-          userId: Parameter.Path(Joi.number()),
-          interest: Parameter.Path(Joi.string().strict()),
-          arrayParameter: Parameter.Query(Joi.array().items(Joi.number().integer())),
+          userId: Parameter.Path(Type.Number()),
+          interest: Parameter.Path(Type.String()),
+          arrayParameter: Parameter.Query(Type.Array(Type.Integer())),
         });
 
         expect(context.params).to.deep.eq({
@@ -95,17 +95,17 @@ describe("RoutingContext", () => {
           });
 
         context.validateAndUpdateParams({
-          testId: Parameter.Query(Joi.number()),
-          encodedParam: Parameter.Query(Joi.string()),
-          update: Parameter.Body(Joi.object({
-            fieldA: Joi.number(),
-            fieldC: Joi.object({
-              c: Joi.number()
+          testId: Parameter.Query(Type.Number()),
+          encodedParam: Parameter.Query(Type.String()),
+          update: Parameter.Body(Type.Object({
+            fieldA: Type.Number(),
+            fieldC: Type.Object({
+              c: Type.Number()
             })
           })),
-          userId: Parameter.Path(Joi.number()),
-          interest: Parameter.Path(Joi.string().strict()),
-          arrayParameter: Parameter.Query(Joi.array().items(Joi.number().integer())),
+          userId: Parameter.Path(Type.Number()),
+          interest: Parameter.Path(Type.String()),
+          arrayParameter: Parameter.Query(Type.Array(Type.Integer())),
         });
 
         expect(context.params).to.deep.eq({
@@ -152,18 +152,18 @@ describe("RoutingContext", () => {
         });
 
         context.validateAndUpdateParams({
-          testId: Parameter.Query(Joi.number()),
-          encodedParam: Parameter.Query(Joi.string()),
-          doubleEncodedParam: Parameter.Query(Joi.string()),
-          update: Parameter.Body(Joi.object({
-            fieldA: Joi.number(),
-            fieldC: Joi.object({
-              c: Joi.number()
-            })
+          testId: Parameter.Query(Type.Number()),
+          encodedParam: Parameter.Query(Type.String()),
+          doubleEncodedParam: Parameter.Query(Type.String()),
+          update: Parameter.Body(Type.Object({
+            fieldA: Type.Number(),
+            fieldC: Type.Object({
+              c: Type.Number(),
+            }),
           })),
-          userId: Parameter.Path(Joi.number()),
-          interest: Parameter.Path(Joi.string().strict()),
-          arrayParameter: Parameter.Query(Joi.array().items(Joi.number().integer())),
+          userId: Parameter.Path(Type.Number()),
+          interest: Parameter.Path(Type.String()),
+          arrayParameter: Parameter.Query(Type.Array(Type.Integer())),
         });
 
         expect(context.params).to.deep.eq({
@@ -196,15 +196,20 @@ describe("RoutingContext", () => {
         });
 
         context.validateAndUpdateParams({
-          update: Parameter.Body(Joi.object({
-            complex: Joi.array().items(Joi.number()).allow(null),
-          }).optional().default({ complex: null })),
+          update: Parameter.Body(
+            Type.Optional(Type.Object({
+              complex: Type.Union([
+                Type.Array(Type.Number()),
+                Type.Null(),
+              ]),
+            })),
+          ),
         });
 
         expect(context.params).to.deep.eq({
-          update: {
-            complex: null,
-          },
+          // update: {
+          //   complex: null,
+          // },
         });
       });
     });

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -18,8 +18,10 @@ describe("RoutingContext", () => {
               fieldB: 54321,
               fieldC: {
                 c: 100,
-              }
-            }
+              },
+              fieldUnknown: false,
+            },
+            unknownBodyParam: "foo",
           }),
           queryStringParameters: {
             "testId": "12345",
@@ -29,6 +31,7 @@ describe("RoutingContext", () => {
             "arrayParameter[1]": "2",
             "arrayParameter[2]": "3",
             "arrayParameter[3]": "4",
+            "unknownQueryParam": "aaa",
           }
         } as any, "request-id", {
           userId: "33",

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -1,4 +1,4 @@
-import { Type } from "@catchfashion/typebox";
+import { Type } from "@serverless-seoul/typebox";
 import { expect } from "chai";
 
 import * as qs from "qs";

--- a/src/ajv.ts
+++ b/src/ajv.ts
@@ -1,0 +1,39 @@
+import * as Ajv from "ajv";
+import * as _ from "lodash";
+
+// @todo find more general way to handle oneOf/anyOf keywords
+// @see https://github.com/ajv-validator/ajv/issues/1231#issuecomment-652227222
+function usePatchedAjv() {
+  const ajvInstance = new Ajv({
+    allErrors: true,
+    async: false,
+    coerceTypes: true,
+    removeAdditional: "all",
+  });
+
+  ajvInstance.removeKeyword("oneOf");
+  ajvInstance.addKeyword("oneOf", {
+    compile: (schemas) => (data) => {
+      for (const schema of schemas) {
+        const validator = ajv.compile(schema);
+        const valid = validator(_.cloneDeep(data));
+
+        if (valid) {
+          validator(data);
+          return valid;
+        }
+      }
+      return false;
+    },
+    modifying: true,
+    metaSchema: {
+      type: "array",
+      items: [{ type: "object" }],
+    },
+    errors: false,
+  });
+
+  return ajvInstance;
+}
+
+export const ajv = usePatchedAjv();

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,8 +1,24 @@
 // List of custom errors
+import { ErrorObject } from "ajv";
 import { Route } from "./route";
 
 export class TimeoutError extends Error {
-  constructor(public readonly route: Route) {
+  public readonly name = "TimeoutError";
+
+  constructor(
+    public readonly route: Route<any, any>
+  ) {
     super("Timeout Error");
+  }
+}
+
+export class ValidationError extends Error {
+  public readonly name = "ValidationError";
+
+  public constructor(
+    public readonly message: string,
+    public readonly details: ErrorObject[],
+  ) {
+    super(message);
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,15 +21,14 @@ export class Middleware<Metadata= any> {
 }
 
 export interface MiddlewareBeforeOptions<Metadata> {
-  routingContext: RoutingContext;
-
-  currentRoute: Route;
+  routingContext: RoutingContext<any, any>;
+  currentRoute: Route<any, any>;
   metadata?: Metadata;
 }
 
 export interface MiddlewareAfterOptions<Metadata> {
-  routingContext: RoutingContext;
-  currentRoute: Route;
+  routingContext: RoutingContext<any, any>;
+  currentRoute: Route<any, any>;
   metadata?: Metadata;
   response: Response;
 }

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,4 +1,4 @@
-import { TStatic } from "@catchfashion/typebox";
+import { TStatic } from "@serverless-seoul/typebox";
 import { Response } from "./lambda-proxy";
 import { Route } from "./route";
 import { RoutingContext } from "./routing-context";

--- a/src/open_api/__test__/index_spec.ts
+++ b/src/open_api/__test__/index_spec.ts
@@ -1,3 +1,4 @@
+import { Type } from "@catchfashion/typebox";
 import { expect } from "chai";
 
 import {
@@ -5,7 +6,6 @@ import {
   Route,
   Router,
   Routes,
-  RoutingContext,
 } from "../../index";
 
 import {
@@ -14,8 +14,6 @@ import {
 } from "../index";
 
 import * as LambdaProxy from "../../lambda-proxy";
-
-import * as Joi from "joi";
 
 describe("OpenAPIRoute", () => {
   const definitions = {
@@ -89,23 +87,26 @@ describe("OpenAPIRoute", () => {
 
   const actionRoutes: Routes = [
     Route.POST("/api", { desc: "a", operationId: "createUser" }, {
-      userId: Parameter.Path(Joi.number().integer()),
-      testerId: Parameter.Query(Joi.number().required()),
-      userIds: Parameter.Query(Joi.array().items(Joi.number())),
-      user: Parameter.Body(Joi.object({
-        name: Joi.string().required(),
-        tags: Joi.array().items(Joi.object({
-          name: Joi.string()
-        }), Joi.string()),
-        test: Joi.object(),
-      }))
-    }, async function(this: RoutingContext) {
+      userId: Parameter.Path(Type.Integer()),
+      testerId: Parameter.Query(Type.Number()),
+      userIds: Parameter.Query(Type.Array(Type.Number())),
+      user: Parameter.Body(Type.Object({
+        name: Type.String(),
+        tags: Type.Array(Type.Union([
+          Type.Object({
+            name: Type.String()
+          }),
+          Type.String(),
+        ])),
+        test: Type.Object({}),
+      })),
+    }, async function() {
       return this.json({});
     }),
-    Route.POST("/api/a", { desc: "a", operationId: "GetAPIa" }, {}, async function(this: RoutingContext) {
+    Route.POST("/api/a", { desc: "a", operationId: "GetAPIa" }, {}, async function() {
       return this.json({});
     }),
-    Route.GET("/api/c", { desc: "a", operationId: "GetApiC" }, {}, async function(this: RoutingContext) {
+    Route.GET("/api/c", { desc: "a", operationId: "GetApiC" }, {}, async function() {
       return this.json({});
     }),
     Route.GET(
@@ -121,7 +122,7 @@ describe("OpenAPIRoute", () => {
         }
       },
       {},
-      async function(this: RoutingContext) {
+      async function() {
         return this.json({
           data: [{
             id: 100,
@@ -144,7 +145,7 @@ describe("OpenAPIRoute", () => {
         }
       },
       {},
-      async function(this: RoutingContext) {
+      async function() {
         return this.json({
           data: [{
             id: 100,

--- a/src/open_api/__test__/index_spec.ts
+++ b/src/open_api/__test__/index_spec.ts
@@ -1,4 +1,4 @@
-import { Type } from "@catchfashion/typebox";
+import { Type } from "@serverless-seoul/typebox";
 import { expect } from "chai";
 
 import {

--- a/src/open_api/index.ts
+++ b/src/open_api/index.ts
@@ -1,10 +1,10 @@
-import * as _ from "lodash";
+import { OptionalModifier, TStatic } from "@catchfashion/typebox";
 import * as OpenApi from "openapi3-ts";
-import JoiToJSONSchema = require("vingle-corgi-joi-to-json-schema");
 
 import * as LambdaProxy from "../lambda-proxy";
 
 import { Namespace, Routes } from "../namespace";
+import { ParameterDefinition, ParameterInputType } from "../parameter";
 import { JSONSchema, Route} from "../route";
 
 import { flattenRoutes } from "../router";
@@ -15,29 +15,7 @@ export type OpenAPIRouteOptions = (
   { definitions?: { [definitionsName: string]: JSONSchema } }
 );
 
-function deepOmit(obj: any, keysToOmit: string[]) {
-  const keysToOmitIndex = _.keyBy(keysToOmit); // create an index object of the keys that should be omitted
-
-  const omitFromObject = (objectToOmit: any) => {
-    // the inner function which will be called recursively
-    return _.transform(objectToOmit, function(result: any, value, key) { // transform to a new object
-      if (key in keysToOmitIndex) { // if the key is in the index skip it
-        return;
-      }
-
-      // if the key is an object run it through the inner function - omitFromObject
-      result[key] = _.isObject(value) ? omitFromObject(value) : value;
-    });
-  };
-
-  return omitFromObject(obj); // return the inner function result
-}
-
-function convertJoiToJSONSchema(joi: any) {
-  return deepOmit(JoiToJSONSchema(joi), ["additionalProperties", "patterns"]);
-}
-
-export class OpenAPIRoute extends Namespace {
+export class OpenAPIRoute extends Namespace<any, any> {
   constructor(
     path: string,
     info: OpenAPIRouteOptions,
@@ -55,7 +33,7 @@ export class OpenAPIRoute extends Namespace {
       };
     };
 
-    super(path, {
+    super(path, {}, {
       children: [
         Route.OPTIONS(
           "", { desc: "CORS Preflight Endpoint for OpenAPI Documentation API", operationId: "optionOpenAPI" }, {},
@@ -87,7 +65,7 @@ export class OpenAPIGenerator {
     const paths: OpenApi.PathsObject = {};
 
     flattenRoutes(cascadedRoutes).forEach((routes) => {
-      const endRoute = (routes[routes.length - 1] as Route);
+      const endRoute = (routes[routes.length - 1] as Route<any, any>);
       const corgiPath = routes.map(r => r.path).join("");
       const OpenAPIPath = this.toOpenAPIPath(corgiPath);
 
@@ -110,56 +88,37 @@ export class OpenAPIGenerator {
           description: endRoute.description,
           operationId: endRoute.operationId,
           parameters:
-            _.flatMap(routes, (route): OpenApi.ParameterObject[] => {
+            routes.flatMap((route): OpenApi.ParameterObject[] => {
               if (route instanceof Namespace) {
                 // Namespace only supports path
-                return _.map(route.params, (schema, name) => {
-                  return {
+                return Object.entries(route.params)
+                  .map(([name, schema]: [string, TStatic]): OpenApi.ParameterObject => ({
                     in: "path",
                     name,
-                    description: schema.describe().description,
-                    schema: {
-                      type: convertJoiToJSONSchema(schema).type,
-                    },
-                    required: true
-                  };
-                });
+                    description: schema.description,
+                    schema,
+                    required: true,
+                  }));
               } else {
-                return _.chain(route.params)
-                  .toPairs()
-                  .filter(r => r[1].in !== "body")
-                  .map(([name, def]) => {
-                    const { description, flags } = def.def.describe();
-
-                    return {
-                      in: def.in as "query",
-                      name,
-                      description,
-                      schema: convertJoiToJSONSchema(def.def),
-                      required: def.in === "path"
-                        || ((flags || {}) as any).presence !== "optional",
-                    };
-                  })
-                  .value();
+                return Object.entries<ParameterDefinition<any>>(route.params)
+                  .filter(([name, param]) => param.in !== "body")
+                  .map(([name, param]): OpenApi.ParameterObject => ({
+                    in: param.in as Exclude<ParameterInputType, "body">,
+                    name,
+                    description: param.def.description,
+                    schema: param.def,
+                    required: param.in === "path" || param.def.modifier !== OptionalModifier,
+                  }));
               }
             }),
           requestBody: (() => {
-            const bodyParams = _.chain(routes)
-              .flatMap((route) => {
-                if (route instanceof Namespace) {
-                  return [];
-                } else {
-                  return _.chain(route.params)
-                    .toPairs()
-                    .filter(r => r[1].in === "body")
-                    .value();
-                }
-              })
-              .map(
-                ([name, paramDef]) =>
-                  ([name, convertJoiToJSONSchema(paramDef.def)])
+            const bodyParams = routes
+              .flatMap((route) => route instanceof Route
+                ? Object.entries<ParameterDefinition<any>>(route.params)
+                    .filter(([name, param]: [string, ParameterDefinition<any>]) => param.in === "body")
+                : []
               )
-              .value();
+              .map(([name, param]) => [name, param.def]);
 
             if (bodyParams.length > 0) {
               return {
@@ -169,11 +128,11 @@ export class OpenAPIGenerator {
                   "application/json": {
                     schema: {
                       type: "object" as const,
-                      properties: _.fromPairs(bodyParams),
-                      required: bodyParams.map(pair => pair[0]),
-                    }
-                  }
-                }
+                      properties: Object.fromEntries(bodyParams),
+                      required: bodyParams.map(([name]) => name),
+                    },
+                  },
+                },
               };
             } else {
               return undefined;
@@ -225,6 +184,6 @@ export class OpenAPIGenerator {
   }
 
   public toOpenAPIPath(path: string) {
-    return path.replace(/\:(\w+)/g, "{$1}");
+    return path.replace(/:(\w+)/g, "{$1}");
   }
 }

--- a/src/open_api/index.ts
+++ b/src/open_api/index.ts
@@ -1,4 +1,4 @@
-import { OptionalModifier, TStatic } from "@catchfashion/typebox";
+import { OptionalModifier, TStatic } from "@serverless-seoul/typebox";
 import * as OpenApi from "openapi3-ts";
 
 import * as LambdaProxy from "../lambda-proxy";

--- a/src/open_api/joi-to-json-schema.d.ts
+++ b/src/open_api/joi-to-json-schema.d.ts
@@ -1,7 +1,0 @@
-declare module "vingle-corgi-joi-to-json-schema" {
-  import { Schema } from 'joi';
-  type JSONSchema = any;
-  function convert(joi: Schema, transformer?: (object: JSONSchema) => JSONSchema): JSONSchema;
-
-  export = convert;
-}

--- a/src/parameter.ts
+++ b/src/parameter.ts
@@ -1,24 +1,20 @@
-import * as Joi from "joi";
+import { TStatic } from "@catchfashion/typebox";
 
-export type ParameterInputType = "query" | "header" | "path" | "formData" | "body";
-export interface ParameterDefinition {
+export type ParameterInputType = "query" | "header" | "path" | "body";
+export interface ParameterDefinition<T extends TStatic> {
   in: ParameterInputType;
-  def: Joi.Schema;
+  def: T;
 }
-export interface ParameterDefinitionMap {
-  [key: string]: ParameterDefinition;
-}
-
 export class Parameter {
-  public static Query(schema: Joi.Schema): ParameterDefinition {
+  public static Query<T extends TStatic>(schema: T): ParameterDefinition<T> {
     return { in: "query", def: schema };
   }
 
-  public static Path(schema: Joi.Schema): ParameterDefinition {
+  public static Path<T extends TStatic>(schema: T): ParameterDefinition<T> {
     return { in: "path", def: schema };
   }
 
-  public static Body(schema: Joi.Schema): ParameterDefinition {
+  public static Body<T extends TStatic>(schema: T): ParameterDefinition<T> {
     return { in: "body", def: schema };
   }
 }

--- a/src/parameter.ts
+++ b/src/parameter.ts
@@ -1,4 +1,4 @@
-import { TStatic } from "@catchfashion/typebox";
+import { TStatic } from "@serverless-seoul/typebox";
 
 export type ParameterInputType = "query" | "header" | "path" | "body";
 export interface ParameterDefinition<T extends TStatic> {

--- a/src/root-namespace.ts
+++ b/src/root-namespace.ts
@@ -4,13 +4,13 @@ import {
 } from "./error_response";
 import { Namespace, Routes } from "./namespace";
 
-export class RootNamespace extends Namespace {
+export class RootNamespace extends Namespace<{}, {}> {
   public readonly errorFormatter: ErrorResponseFormatter;
 
   constructor(children: Routes) {
     const errorFormatter = new ErrorResponseFormatter(process.env.CORGI_ERROR_PASSSWORD);
 
-    super("", {
+    super("", {}, {
       async exceptionHandler(error: Error) {
         if (error instanceof StandardError) {
           return this.json({

--- a/src/route.ts
+++ b/src/route.ts
@@ -1,4 +1,4 @@
-import { TStatic } from "@catchfashion/typebox";
+import { TStatic } from "@serverless-seoul/typebox";
 import * as _ from "lodash";
 
 import * as LambdaProxy from "./lambda-proxy";

--- a/src/route.ts
+++ b/src/route.ts
@@ -1,49 +1,79 @@
+import { TStatic } from "@catchfashion/typebox";
 import * as _ from "lodash";
 
 import * as LambdaProxy from "./lambda-proxy";
-import { ParameterDefinitionMap } from "./parameter";
+import { ParameterDefinition } from "./parameter";
 import { RoutingContext } from "./routing-context";
 
 import { Middleware, MiddlewareConstructor } from "./middleware";
 
 export type HttpMethod = "GET" | "PUT" | "POST" | "PATCH" | "DELETE" | "OPTIONS" | "HEAD";
-export type RouteHandler = (this: RoutingContext) => Promise<LambdaProxy.Response>;
+export type RouteHandler<
+  T extends { [P in keyof T]: ParameterDefinition<any> },
+  U extends { [P in keyof U]: TStatic }
+> = (this: RoutingContext<T, U>) => Promise<LambdaProxy.Response>;
 export type RouteMetadata = Map<Function, any>; // tslint:disable-line
 
 // ---- Route
-export class Route {
+export class Route<
+  T extends { [P in keyof T]: ParameterDefinition<any> },
+  U extends { [P in keyof U]: TStatic }
+> {
 
   // Simplified Constructors
-  // tslint:disable:max-line-length
-  public static GET(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
-    return this._factory(path, "GET", options, params, handler);
+  public static GET<
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, handler: RouteHandler<T, U>) {
+    return this._factory<T, U>(path, "GET", options, params, handler);
   }
-  public static PUT(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+  public static PUT<
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, handler: RouteHandler<T, U>) {
     return this._factory(path, "PUT", options, params, handler);
   }
-  public static POST(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+  public static POST<
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, handler: RouteHandler<T, U>) {
     return this._factory(path, "POST", options, params, handler);
   }
-  public static PATCH(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+  public static PATCH<
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, handler: RouteHandler<T, U>) {
     return this._factory(path, "PATCH", options, params, handler);
   }
-  public static DELETE(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+  public static DELETE<
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, handler: RouteHandler<T, U>) {
     return this._factory(path, "DELETE", options, params, handler);
   }
-  public static OPTIONS(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+  public static OPTIONS<
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, handler: RouteHandler<T, U>) {
     return this._factory(path, "OPTIONS", options, params, handler);
   }
-  public static HEAD(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, handler: RouteHandler) {
+  public static HEAD<
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, handler: RouteHandler<T, U>) {
     return this._factory(path, "HEAD", options, params, handler);
   }
   // tslint:enable:max-line-length
 
-  private static _factory(
+  private static _factory<
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(
     path: string,
     method: HttpMethod,
     options: RouteSimplifiedOptions,
-    params: ParameterDefinitionMap,
-    handler: RouteHandler
+    params: T,
+    handler: RouteHandler<T, U>
   ) {
     return new this({
       path,
@@ -59,18 +89,18 @@ export class Route {
   public readonly path: string;
   public readonly method: HttpMethod;
   public readonly description: string | undefined;
-  public readonly handler: RouteHandler;
-  public readonly params: ParameterDefinitionMap | undefined;
+  public readonly handler: RouteHandler<T, U>;
+  public readonly params: T;
   public readonly operationId: string;
   public readonly responses: Map<number, ResponseSchema> | undefined;
   public readonly metadata: RouteMetadata;
 
-  constructor(options: RouteOptions) {
+  constructor(options: RouteOptions<T, U>) {
     this.path = options.path;
     this.method = options.method;
     this.description = options.desc;
     this.handler = options.handler;
-    this.params = options.params;
+    this.params = options.params || {} as T;
     this.operationId = options.operationId;
     this.responses = options.responses ? new Map(
       _.toPairs(options.responses || {})
@@ -91,15 +121,18 @@ export interface RouteSimplifiedOptions {
   metadata?: RouteMetadata;
 }
 
-export interface RouteOptions {
+export interface RouteOptions<
+  T extends { [P in keyof T]: ParameterDefinition<any> },
+  U extends { [P in keyof U]: TStatic }
+> {
   path: string;
   method: HttpMethod;
   desc?: string;
   operationId: string;
   responses?: { [statusCode: number]: ResponseSchema };
   metadata?: RouteMetadata;
-  params?: ParameterDefinitionMap;
-  handler: RouteHandler;
+  params?: T;
+  handler: RouteHandler<T, U>;
 }
 
 export interface ResponseSchema {

--- a/src/route_factories/presenter_route/presenter_route.ts
+++ b/src/route_factories/presenter_route/presenter_route.ts
@@ -15,7 +15,7 @@ export type PresenterRouteHandler<
   Input,
   T extends { [P in keyof T]: ParameterDefinition<any> },
   U extends { [P in keyof U]: TStatic }
-> = (this: RoutingContext<T, U>) => Promise<Input>;
+> = unknown extends Input ? never : (this: RoutingContext<T, U>) => Promise<Input>;
 
 export class PresenterRouteFactory {
   public static create<
@@ -45,7 +45,7 @@ export class PresenterRouteFactory {
       metadata: options.metadata,
       params,
       async handler() {
-        const res = (await (handler.call(this) as Promise<Entity>));
+        const res = await handler.call(this);
         return this.json(await presenter.present(res));
       },
     });

--- a/src/route_factories/presenter_route/presenter_route.ts
+++ b/src/route_factories/presenter_route/presenter_route.ts
@@ -1,5 +1,6 @@
+import { TStatic } from "@catchfashion/typebox";
 import {
-  ParameterDefinitionMap,
+  ParameterDefinition,
 } from "../../parameter";
 import {
   HttpMethod,
@@ -10,17 +11,27 @@ import { RoutingContext } from "../../routing-context";
 
 import { Presenter } from "./presenter";
 
-export type PresenterRouteHandler<Input> = (this: RoutingContext) => Promise<Input>;
+export type PresenterRouteHandler<
+  Input,
+  T extends { [P in keyof T]: ParameterDefinition<any> },
+  U extends { [P in keyof U]: TStatic }
+> = (this: RoutingContext<T, U>) => Promise<Input>;
+
 export class PresenterRouteFactory {
-  public static create<Entity, Output>(
+  public static create<
+    Entity,
+    Output,
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(
     path: string,
     method: HttpMethod,
     options: RouteSimplifiedOptions,
-    params: ParameterDefinitionMap,
+    params: T,
     presenter: Presenter<Entity, Output>,
-    handler: PresenterRouteHandler<Entity>
-  ): Route {
-    return new Route({
+    handler: PresenterRouteHandler<Entity, T, U>
+  ): Route<T, U> {
+    return new Route<T, U>({
       path,
       method,
       desc: options.desc,
@@ -42,25 +53,60 @@ export class PresenterRouteFactory {
 
   // Simplified Constructors
   // tslint:disable:max-line-length
-  public static GET<Input, Output>(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input>) {
+  public static GET<
+    Input,
+    Output,
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input, T, U>) {
     return this.create(path, "GET", options, params, presenter, handler);
   }
-  public static POST<Input, Output>(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input>) {
+  public static POST<
+    Input,
+    Output,
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input, T, U>) {
     return this.create(path, "POST", options, params, presenter, handler);
   }
-  public static PUT<Input, Output>(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input>) {
+  public static PUT<
+    Input,
+    Output,
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input, T, U>) {
     return this.create(path, "PUT", options, params, presenter, handler);
   }
-  public static PATCH<Input, Output>(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input>) {
+  public static PATCH<
+    Input,
+    Output,
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input, T, U>) {
     return this.create(path, "PATCH", options, params, presenter, handler);
   }
-  public static DELETE<Input, Output>(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input>) {
+  public static DELETE<
+    Input,
+    Output,
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input, T, U>) {
     return this.create(path, "DELETE", options, params, presenter, handler);
   }
-  public static OPTIONS<Input, Output>(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input>) {
+  public static OPTIONS<
+    Input,
+    Output,
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input, T, U>) {
     return this.create(path, "OPTIONS", options, params, presenter, handler);
   }
-  public static HEAD<Input, Output>(path: string, options: RouteSimplifiedOptions, params: ParameterDefinitionMap, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input>) {
+  public static HEAD<
+    Input,
+    Output,
+    T extends { [P in keyof T]: ParameterDefinition<any> },
+    U extends { [P in keyof U]: TStatic }
+  >(path: string, options: RouteSimplifiedOptions, params: T, presenter: Presenter<Input, Output>, handler: PresenterRouteHandler<Input, T, U>) {
     return this.create(path, "HEAD", options, params, presenter, handler);
   }
   // tslint:enable:max-line-length

--- a/src/route_factories/presenter_route/presenter_route.ts
+++ b/src/route_factories/presenter_route/presenter_route.ts
@@ -1,4 +1,4 @@
-import { TStatic } from "@catchfashion/typebox";
+import { TStatic } from "@serverless-seoul/typebox";
 import {
   ParameterDefinition,
 } from "../../parameter";

--- a/src/routing-context.ts
+++ b/src/routing-context.ts
@@ -1,19 +1,12 @@
 import { Static, TObject, TStatic, Type } from "@serverless-seoul/typebox";
-import * as Ajv from "ajv";
 import * as _ from "lodash";
 import * as qs from "qs";
 import { ValidationError } from "./errors";
 import * as LambdaProxy from "./lambda-proxy";
 
+import { ajv } from "./ajv";
 import { ParameterDefinition, ParameterInputType } from "./parameter";
 import { Router } from "./router";
-
-const ajv = new Ajv({
-  allErrors: true,
-  async: false,
-  coerceTypes: true,
-  removeAdditional: "all",
-});
 
 type ParameterType<T extends { [P in keyof T]: TStatic }> = string extends keyof T
   ? {}

--- a/src/routing-context.ts
+++ b/src/routing-context.ts
@@ -1,4 +1,4 @@
-import { Static, TOptional, TStatic, Type } from "@serverless-seoul/typebox";
+import { Static, TObject, TStatic, Type } from "@serverless-seoul/typebox";
 import * as Ajv from "ajv";
 import * as _ from "lodash";
 import * as qs from "qs";
@@ -15,17 +15,17 @@ const ajv = new Ajv({
   removeAdditional: "all",
 });
 
-type NamespaceParameterType<T extends { [P in keyof T]: TStatic }> = string extends keyof T
+type ParameterType<T extends { [P in keyof T]: TStatic }> = string extends keyof T
   ? {}
-  : { [P in keyof T]: Static<T[P]> };
+  : Static<TObject<T>>;
 
-type RouteParameterType<T extends { [P in keyof T]: ParameterDefinition<any> }> = string extends keyof T
-  ? {}
-  : { [P in keyof T]: T[P] extends TOptional<any> ? Static<T[P]["def"]> : Static<T[P]> };
+type ExtractParameter<T extends { [P in keyof T]: ParameterDefinition<TStatic> }> = {
+  [P in keyof T]: T[P]["def"];
+};
 
 // ---- RoutingContext
 export class RoutingContext<
-  T extends { [P in keyof T]: ParameterDefinition<any> },
+  T extends { [P in keyof T]: ParameterDefinition<TStatic> },
   U extends { [P in keyof U]: TStatic } = {}
 > {
 
@@ -65,9 +65,9 @@ export class RoutingContext<
   }
   private readonly validatedParams:
     // Inferred Namespace Parameter
-    NamespaceParameterType<U> &
+    ParameterType<U> &
     // Inferred Route Parameter
-    RouteParameterType<T> &
+    ParameterType<ExtractParameter<T>> &
     // Unknown keys should be unknown type
     // Below type is just for assigning custom parameter in Namespace#before
     { [key: string]: unknown };

--- a/src/routing-context.ts
+++ b/src/routing-context.ts
@@ -1,20 +1,25 @@
-import * as Joi from "joi";
+import { Static, TStatic, Type } from "@catchfashion/typebox";
+import * as Ajv from "ajv";
 import * as _ from "lodash";
 import * as qs from "qs";
+import { ValidationError } from "./errors";
 import * as LambdaProxy from "./lambda-proxy";
 
-import { ParameterDefinitionMap } from "./parameter";
+import { ParameterDefinition, ParameterInputType } from "./parameter";
 import { Router } from "./router";
 
-//
-const DefaultJoiValidateOptions: Joi.ValidationOptions = {
-  stripUnknown: true,
-  presence: "required",
-  abortEarly: false,
-};
+const ajv = new Ajv({
+  allErrors: true,
+  async: false,
+  coerceTypes: true,
+  removeAdditional: "all",
+});
 
 // ---- RoutingContext
-export class RoutingContext {
+export class RoutingContext<
+  T extends { [P in keyof T]: ParameterDefinition<any> },
+  U extends { [P in keyof U]: TStatic } = {}
+> {
 
   get headers(): LambdaProxy.Event["headers"] {
     // normalize works lazily and should be cached for further use
@@ -50,7 +55,10 @@ export class RoutingContext {
       }
     }
   }
-  private validatedParams: { [key: string]: any };
+  private readonly validatedParams:
+    (string extends keyof U ? {} : { [P in keyof U]: Static<U[P]> }) &
+    (string extends keyof T ? {} : { [P in keyof T]: Static<T[P]["def"]> }) &
+    { [key: string]: unknown };
   private normalizedHeaders: { [key: string]: string } | null;
 
   constructor(
@@ -59,35 +67,32 @@ export class RoutingContext {
     public readonly requestId: string | undefined,
     private pathParams: { [key: string]: string }
   ) {
-    this.validatedParams = {};
+    this.validatedParams = {} as any;
     this.normalizedHeaders = null;
   }
 
-  public validateAndUpdateParams(parameterDefinitionMap: ParameterDefinitionMap) {
-    const groupByIn: {
-      [key: string]: { [key: string]: Joi.Schema }
-    } = {};
+  public validateAndUpdateParams(parameterDefinitionMap: { [key: string]: ParameterDefinition<any> }) {
+    const groupByIn = Object.entries(parameterDefinitionMap).reduce((hash, [name, schema]) => {
+      hash[schema.in] ||= {};
+      hash[schema.in]![name] = schema.def;
 
-    _.forEach(parameterDefinitionMap, (schema, name) => {
-      if (!groupByIn[schema.in]) {
-        groupByIn[schema.in] = {};
-      }
-
-      groupByIn[schema.in][name] = schema.def;
+      return hash;
+    }, {} as {
+      [k in ParameterInputType]?: {
+        [key: string]: ParameterDefinition<any>;
+      };
     });
 
-    const validate = (rawParams: any, schemaMap: { [key: string]: Joi.Schema }) => {
-      const res = Joi.validate(
-        rawParams || {},
-        Joi.object(schemaMap),
-        DefaultJoiValidateOptions,
-      );
+    const validate = (rawParams: any, schemaMap: { [key: string]: TStatic }) => {
+      const params = _.cloneDeep(rawParams ?? {});
+      const valid = ajv.validate(Type.Object(schemaMap), params);
 
-      if (res.error) {
-        throw res.error;
-      } else {
-        Object.assign(this.validatedParams, res.value);
+      if (!valid) {
+        const errors = ajv.errors!;
+        throw new ValidationError(ajv.errorsText(errors), errors);
       }
+
+      Object.assign(this.validatedParams, params);
     };
 
     if (groupByIn.path) {

--- a/src/routing-context.ts
+++ b/src/routing-context.ts
@@ -1,4 +1,4 @@
-import { Static, TStatic, Type } from "@catchfashion/typebox";
+import { Static, TStatic, Type } from "@serverless-seoul/typebox";
 import * as Ajv from "ajv";
 import * as _ from "lodash";
 import * as qs from "qs";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2019",
     "noImplicitAny": true,
     "sourceMap": true,
+    "rootDir": "src",
     "outDir": "dst",
     "strict": false,
     "strictNullChecks": true,
@@ -11,8 +12,7 @@
     "emitDecoratorMetadata": true,
     "noUnusedLocals": true,
     "lib": [
-      "es2017",
-      "esnext.asynciterable"
+      "es2019"
     ]
   },
   "exclude": [

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,21 +1,4 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2017",
-    "noImplicitAny": true,
-    "sourceMap": true,
-    "outDir": "dst",
-    "strict": false,
-    "strictNullChecks": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "noUnusedLocals": true,
-    "lib": [
-      "es2017",
-      "esnext.asynciterable"
-    ]
-  },
-  "include": [
-    "src/**/*"
-  ]
+  "extends": "./tsconfig.json",
+  "exclude": []
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
   "exclude": []
 }


### PR DESCRIPTION
![Preview](https://user-images.githubusercontent.com/2101743/94349498-c754c480-007f-11eb-9774-c2d9696c727d.gif)


#### Is it a breaking change?: Yes

### Why did you make these changes?

- No more manual parameter type casting (e.g. `this.params.foo as string | undefined` - 😫)

### What's changed in these changes?

- Support Parameter Type inference using Typebox - which is based on JSONSchema (no additional JSONSchema conversion is no more required)
- Removed Joi Support
- Support JSONSchema merging (e.g. Share same JSONSchema between Request Parameter / Response Entity)

### What do you especially want to get reviewed?

N/A

### Is there any other comments that every teammate should know?

- Parameter constructor signature is changed:

```typescript
// OLD
new Namespace(path, options);

// NEW
new Namespace(path, param, options); // now parameter is defined in constructor arguments
```

- Requires TypeScript 4 and Node.js 12 

corgi V4 is no more compatible with TypeScript 3 and Node.js 10 due to unsupported syntax (e.g. Variadic tuple types, Array#flatMap, etc)

- corgi-cli usage is now deprecated

Just use Typebox to generate JSONSchema


### Submission Type

* [x] Bugfix
* [x] New Feature
* [x] Refactor

### All Submissions

* [x] Have you added an explanation of what your changes?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you checked potential side effects that could make bad impacts to other services?

