### PR TITLE
fix(parameter): make object type coercion to last resort

### DIFF
--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -32,6 +32,21 @@ describe("RoutingContext", () => {
             "arrayParameter[2]": "3",
             "arrayParameter[3]": "4",
             "unknownQueryParam": "aaa",
+            "queryString": JSON.stringify({ foo: 123 }),
+            "queryObject": JSON.stringify({ foo: "a", bar: 1 }),
+            "queryUnion": JSON.stringify({ type: "bar", bar: 3 }),
+            "queryArray": JSON.stringify([{
+              a: "aaa",
+              b: 1,
+              c: true,
+              d: null,
+              e: "e",
+            }, {
+              a: "aaa",
+              b: 1,
+              c: true,
+              d: null,
+            }]),
           }
         } as any, "request-id", {
           userId: "33",
@@ -41,6 +56,29 @@ describe("RoutingContext", () => {
         context.validateAndUpdateParams({
           testId: Parameter.Query(Type.Number()),
           encodedParam: Parameter.Query(Type.String()),
+          queryString: Parameter.Query(Type.String()),
+          queryObject: Parameter.Query(Type.Object({
+            foo: Type.String(),
+            bar: Type.Integer(),
+            baz: Type.Optional(Type.Boolean()),
+          })),
+          queryUnion: Parameter.Query(Type.Union([
+            Type.Object({
+              type: Type.Literal("foo"),
+              foo: Type.String(),
+            }),
+            Type.Object({
+              type: Type.Literal("bar"),
+              bar: Type.Number(),
+            }),
+          ])),
+          queryArray: Parameter.Query(Type.Array(Type.Object({
+            a: Type.String(),
+            b: Type.Integer(),
+            c: Type.Boolean(),
+            d: Type.Null(),
+            e: Type.Optional(Type.Literal("e")),
+          }))),
           update: Parameter.Body(Type.Object({
             fieldA: Type.Number(),
             fieldC: Type.Object({
@@ -64,6 +102,21 @@ describe("RoutingContext", () => {
           userId: 33,
           interest: "픽시",
           arrayParameter: [1, 2, 3, 4],
+          queryString: JSON.stringify({ foo: 123 }),
+          queryObject: { foo: "a", bar: 1 },
+          queryUnion: { type: "bar", bar: 3 },
+          queryArray: [{
+            a: "aaa",
+            b: 1,
+            c: true,
+            d: null,
+            e: "e",
+          }, {
+            a: "aaa",
+            b: 1,
+            c: true,
+            d: null,
+          }],
         });
       });
 


### PR DESCRIPTION
#### Is it a breaking change?: NO

### Why did you make these changes?

Currently JSON string cannot be used as plain string parameter due to forced type casting.

### What's changed in these changes?

Make object type coercion to last resort 

### What do you especially want to get reviewed?

N/A

### Is there any other comments that every teammate should know?

N/A


### Submission Type

* [x] Bugfix


### All Submissions

* [x] Have you added an explanation of what your changes?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you checked potential side effects that could make bad impacts to other services?
