### PR TITLE
apply multiValueQueryStringParameters

### DIFF
--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -125,20 +125,44 @@ describe("RoutingContext", () => {
           httpMethod: "GET",
           queryStringParameters: {
             "a": "[1, 2]",
+            "b[0]": "1",
+            "b[1]": "2",
+            "c[]": "2",
+            "d": "2",
           },
           multiValueQueryStringParameters: {
             "a": [
               "[1, 2]"
             ],
+            "b[0]": [
+              "1"
+            ],
+            "b[1]": [
+              "2"
+            ],
+            "c[]": [
+              "1",
+              "2",
+            ],
+            "d": [
+              "1",
+              "2",
+            ]
           }
         } as any, "request-id", {});
 
         context.validateAndUpdateParams({
           a: Parameter.Query(Type.Array(Type.String())),
+          b: Parameter.Query(Type.Array(Type.String())),
+          c: Parameter.Query(Type.Array(Type.String())),
+          d: Parameter.Query(Type.Array(Type.String())),
         });
 
         expect(context.params).to.deep.eq({
           a: ["1", "2"],
+          b: ["1", "2"],
+          c: ["1", "2"],
+          d: ["1", "2"],
         });
       });
 

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -27,7 +27,10 @@ describe("RoutingContext", () => {
             "testId": "12345",
             "not_allowed_param": "xxx",
             "encodedParam": "픽시",
-            "arrayParameter[]": "4",
+            "arrayParameter[0]": "1",
+            "arrayParameter[1]": "2",
+            "arrayParameter[2]": "3",
+            "arrayParameter[3]": "4",
             "unknownQueryParam": "aaa",
             "queryString": JSON.stringify({ foo: 123 }),
             "queryObject": JSON.stringify({ foo: "a", bar: 1 }),
@@ -44,8 +47,6 @@ describe("RoutingContext", () => {
               c: true,
               d: null,
             }]),
-          }, multiValueQueryStringParameters: {
-            "arrayParameter[]": ["1", "2", "3", "4"]
           }
         } as any, "request-id", {
           userId: "33",
@@ -190,10 +191,10 @@ describe("RoutingContext", () => {
             "testId": "12345",
             "not_allowed_param": "xxx",
             "encodedParam": "픽시",
-            "arrayParameter[]": "4",
-          },
-          multiValueQueryStringParameters: {
-            "arrayParameter[]": ["1", "2", "3", "4"],
+            "arrayParameter[0]": "1",
+            "arrayParameter[1]": "2",
+            "arrayParameter[2]": "3",
+            "arrayParameter[3]": "4",
           }
         } as any, "request-id", {
             userId: "33",
@@ -247,9 +248,10 @@ describe("RoutingContext", () => {
             "not_allowed_param": "xxx",
             "encodedParam": "100%users",
             "doubleEncodedParam": "vingle%3A%2F%2Finterests%2F%EB%B9%99%EA%B8%80%EB%9F%AC",
-            "arrayParameter[]": "4",
-          }, multiValueQueryStringParameters: {
-            "arrayParameter[]": ["1", "2", "3", "4"],
+            "arrayParameter[0]": "1",
+            "arrayParameter[1]": "2",
+            "arrayParameter[2]": "3",
+            "arrayParameter[3]": "4",
           }
         } as any, "request-id", {
           userId: "33",

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -120,6 +120,27 @@ describe("RoutingContext", () => {
         });
       });
 
+      it("should parse and validate multiple value parameters in querystring", () => {
+        const context = new RoutingContext({} as any, {
+          path: "/api",
+          httpMethod: "GET",
+          queryStringParameters: {
+            "a": ["2"],
+          },
+          multiValueQueryStringParameters: {
+            "a": ["1", "2"],
+          }
+        } as any, "request-id", {});
+
+        context.validateAndUpdateParams({
+          a: Parameter.Query(Type.Array(Type.String())),
+        });
+
+        expect(context.params).to.deep.eq({
+          a: ["1", "2"],
+        });
+      });
+
       it("should parse and validate application/x-www-form-urlencoded params", () => {
         const context = new RoutingContext({} as any, {
           path: "/api/33/followings/%ED%94%BD%EC%8B%9C",

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -120,6 +120,10 @@ describe("RoutingContext", () => {
       });
 
       it("should parse and validate multiple value parameters in querystring", () => {
+        // ?a=[1,2]
+        // ?b[0]=1&b[1]=2
+        // ?c[]=1&c[]=2
+        // ?d=1&d=2
         const context = new RoutingContext({} as any, {
           path: "/api",
           httpMethod: "GET",

--- a/src/__test__/routing-context_spec.ts
+++ b/src/__test__/routing-context_spec.ts
@@ -27,10 +27,7 @@ describe("RoutingContext", () => {
             "testId": "12345",
             "not_allowed_param": "xxx",
             "encodedParam": "픽시",
-            "arrayParameter[0]": "1",
-            "arrayParameter[1]": "2",
-            "arrayParameter[2]": "3",
-            "arrayParameter[3]": "4",
+            "arrayParameter[]": "4",
             "unknownQueryParam": "aaa",
             "queryString": JSON.stringify({ foo: 123 }),
             "queryObject": JSON.stringify({ foo: "a", bar: 1 }),
@@ -47,6 +44,8 @@ describe("RoutingContext", () => {
               c: true,
               d: null,
             }]),
+          }, multiValueQueryStringParameters: {
+            "arrayParameter[]": ["1", "2", "3", "4"]
           }
         } as any, "request-id", {
           userId: "33",
@@ -125,10 +124,12 @@ describe("RoutingContext", () => {
           path: "/api",
           httpMethod: "GET",
           queryStringParameters: {
-            "a": ["2"],
+            "a": "[1, 2]",
           },
           multiValueQueryStringParameters: {
-            "a": ["1", "2"],
+            "a": [
+              "[1, 2]"
+            ],
           }
         } as any, "request-id", {});
 
@@ -161,10 +162,10 @@ describe("RoutingContext", () => {
             "testId": "12345",
             "not_allowed_param": "xxx",
             "encodedParam": "픽시",
-            "arrayParameter[0]": "1",
-            "arrayParameter[1]": "2",
-            "arrayParameter[2]": "3",
-            "arrayParameter[3]": "4",
+            "arrayParameter[]": "4",
+          },
+          multiValueQueryStringParameters: {
+            "arrayParameter[]": ["1", "2", "3", "4"],
           }
         } as any, "request-id", {
             userId: "33",
@@ -218,10 +219,9 @@ describe("RoutingContext", () => {
             "not_allowed_param": "xxx",
             "encodedParam": "100%users",
             "doubleEncodedParam": "vingle%3A%2F%2Finterests%2F%EB%B9%99%EA%B8%80%EB%9F%AC",
-            "arrayParameter[0]": "1",
-            "arrayParameter[1]": "2",
-            "arrayParameter[2]": "3",
-            "arrayParameter[3]": "4",
+            "arrayParameter[]": "4",
+          }, multiValueQueryStringParameters: {
+            "arrayParameter[]": ["1", "2", "3", "4"],
           }
         } as any, "request-id", {
           userId: "33",

--- a/src/routing-context.ts
+++ b/src/routing-context.ts
@@ -107,6 +107,7 @@ export class RoutingContext<
       // API Gateway only support string parsing.
       // but with this, now it would support Array<String> / Map<String, String> parsing too
       const queryStringParameters = qs.parse(qs.stringify(this.request.queryStringParameters));
+      const multiValueQueryStringParameters = qs.parse(qs.stringify(this.request.multiValueQueryStringParameters));
 
       // AJV does not support non-scalar type coercion (e.g. String <-> Object)
       // Due to this limitation, we have to iterate each schemas, try validate with manual type casting
@@ -116,7 +117,7 @@ export class RoutingContext<
 
         try {
           validate({
-            [key]: queryStringParameters[key],
+            [key]: multiValueQueryStringParameters[key] ?? queryStringParameters[key],
           }, {
             [key]: schema,
           });

--- a/src/routing-context.ts
+++ b/src/routing-context.ts
@@ -117,12 +117,10 @@ export class RoutingContext<
 
         const value = schema.type === "array"
           ? (() => {
-              try {
-                // handle case like ?a=[1,2,3,4]
-                if (JSON.parse(queryStringParameters[key] as any) instanceof Array) {
-                  return queryStringParameters[key];
-                }
-              } catch (e) {}
+              const casted = this.castJSON(queryStringParameters[key]);
+              if (casted instanceof Array) {
+                return casted;
+              }
               return multiValueQueryStringParameters[key];
             })()
           : queryStringParameters[key];


### PR DESCRIPTION
#### Is it a breaking change?: NO

### Why did you make these changes?

There are several ways to pass array value using query string:

```
?a[]=1&a[]=2
?a[0]=1&a[1]=2
?a=1&a=2
?a=[1,2]
```

but using only 'queryStringParameters' field in API Gateway proxy event doesn't handle all those cases above.

To make it works, we should use 'multiValueQueryStringParameters' also.

### What's changed in these changes?

find query parameter value from 'multiValueQueryStringParameters' first.

### What do you especially want to get reviewed?

N/A

### Is there any other comments that every teammate should know?

N/A


### Submission Type

* [ ] Bugfix
* [x] New Feature
* [ ] Refactor

### All Submissions

* [x] Have you added an explanation of what your changes?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you checked potential side effects that could make bad impacts to other services?
